### PR TITLE
Fixing the workaround for variant document identification

### DIFF
--- a/packages/reaction-core/server/import.js
+++ b/packages/reaction-core/server/import.js
@@ -40,14 +40,7 @@ ReactionImport.startup = function () {
 ReactionImport.load = function (key, object) {
   check(object, Object);
 
-  // todo fix this workaround
-  let collection;
-  if (object.type && object.type === "variant") {
-    collection = ReactionCore.Collections.Products;
-  } else {
-    collection = this.identify(object);
-  }
-  this.object(collection, key, object);
+  this.object(this.identify(object), key, object);
 };
 
 ReactionImport.indication = function (field, collection, probability) {
@@ -443,7 +436,9 @@ ReactionImport.process = function (json, keys, callback) {
 
 ReactionImport.indication("i18n", ReactionCore.Collections.Translations, 0.2);
 ReactionImport.indication("hashtags", ReactionCore.Collections.Products, 0.5);
-ReactionImport.indication("variants", ReactionCore.Collections.Products, 0.5);
+ReactionImport.indication("barcode", ReactionCore.Collections.Products, 0.5);
+ReactionImport.indication("price", ReactionCore.Collections.Products, 0.5);
+ReactionImport.indication("ancestors", ReactionCore.Collections.Products, 0.5);
 ReactionImport.indication("languages", ReactionCore.Collections.Shops, 0.5);
 ReactionImport.indication("currencies", ReactionCore.Collections.Shops, 0.5);
 ReactionImport.indication("timezone", ReactionCore.Collections.Shops, 0.5);


### PR DESCRIPTION
Needs to be reviewed, but I think this should do the trick. This doesn't change the `product()` function however, which also needs reviewing.

It is clearly an improvement, because the `load()` function didn't support variants before. It might be interesting to add some test-cases, because the `identify()` could start doing very weird stuff if it's not kept up to date.
